### PR TITLE
Publish .NET NuGet Package - v0.0.1

### DIFF
--- a/.github/workflows/dotnet-publish-nuget-ci.yml
+++ b/.github/workflows/dotnet-publish-nuget-ci.yml
@@ -1,0 +1,68 @@
+# GitHub Actions workflow to publish NuGet package using trusted publishing
+name: Publish NuGet Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: 'Version tag to use for package naming'
+        required: true
+
+# Define the job that will run when the workflow is triggered  
+jobs:
+  publish-nuget:
+    # Run the job on the latest Ubuntu virtual machine
+    runs-on: ubuntu-latest
+    
+    # Set permissions required for trusted publishing
+    # id-token: write enables GitHub OIDC token issuance for trusted publishing
+    permissions:
+      id-token: write  # Enable GitHub OIDC token issuance for trusted publishing
+    
+    # Define the steps that will be executed in sequence
+    steps:
+      # Step 1: Check out the repository code from the main branch
+      - uses: actions/checkout@v4  # Get the latest code from the repository
+      
+      # Step 2: Setup .NET SDK
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4  # Install the .NET SDK
+        with:
+          dotnet-version: 8.0.x 
+      
+      # Step 3: Restore NuGet packages
+      - name: Restore dependencies
+        run: dotnet restore  # Download and restore all project dependencies
+      
+      # Step 4: Build the project in Release configuration
+      - name: Build
+        run: dotnet build ../dotnet-package/Dz.RibRipValidator/Dz.RibRipValidator.csproj --no-restore --configuration Release
+      
+      # Step 5: Create the NuGet package
+      - name: Pack NuGet package
+        run: dotnet pack ../dotnet-package/Dz.RibRipValidator/Dz.RibRipValidator.csproj --no-build --configuration Release --output ../dotnet-package/nupkg  # Package the library into a .nupkg file
+      
+      # Step 6: Extract version from input
+      - name: Extract version from input
+        id: version
+        run: |
+          # Get the version from input and remove the 'v' prefix if present
+          INPUT_VERSION="${{ inputs.version_tag }}"
+          VERSION=${INPUT_VERSION#v}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Extracted version: ${VERSION}"
+      
+      # Step 7: Login to NuGet using trusted publishing
+      - name: NuGet login (trusted publishing)
+        uses: NuGet/login@v1  # Use the official NuGet login action for trusted publishing
+        id: login  # Set an ID so we can reference the output later
+        with:
+          user: ${{ secrets.NUGET_USERNAME }}  # NuGet.org username (stored as a GitHub secret)
+      
+      # Step 8: Publish the package to NuGet.org
+      - name: Publish to NuGet.org
+        run: |
+          # Construct the package file name using the extracted version
+          PACKAGE_PATH="../dotnet-package/nupkg/InzSoftwares.AlgerianRibRipValidator.${{ steps.version.outputs.version }}.nupkg"
+          echo "Publishing package: $PACKAGE_PATH"
+          dotnet nuget push "$PACKAGE_PATH" --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/dotnet-package/Dz.RibRipValidator/Dz.RibRipValidator.csproj
+++ b/dotnet-package/Dz.RibRipValidator/Dz.RibRipValidator.csproj
@@ -5,17 +5,14 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <!-- TODO Validate pacakge name-->
-        <PackageId>Hakim213DZ.AlgerianRibRipValidator</PackageId>
+        <PackageId>InzSoftwares.AlgerianRibRipValidator</PackageId>
         <PackageVersion>0.0.1</PackageVersion>
         <Authors>Abdellah Addoun</Authors>
-        <!-- TODO Validate company name-->
-        <Company>Hakim213 DZ Softwares</Company>
+        <Company>Inz Softwares</Company>
         <Product>Algerian (DZ) RIB and RIP Validator</Product>
         <RepositoryUrl>https://github.com/itshakim213/rib-validator-dz</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <!-- TODO Validate the copyright label-->
-        <Copyright>Copyright (c) itshakim213 2025</Copyright>
+        <Copyright>Copyright (c) 2025 HaKim</Copyright>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <Description>
             A Lighweight .NET package to valiadate any algerian RIB (Relevé d'Identité Bancaire) or RIP (Relevé d'Identité Postal) code according to

--- a/dotnet-package/Dz.RibRipValidator/LICENSE
+++ b/dotnet-package/Dz.RibRipValidator/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 HaKim 👨🏻‍💻
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This PR contains the final details of the NuGet package for version 0.0.1 and a Github action to publish newer versions manually from Github.
_**Important Note:**_ A required secret variable needs to be set in the repo for th action to work, the secret variable key should be labeled `NUGET_USERNAME`